### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #73)

### DIFF
--- a/.claude/commands/docs-create.md
+++ b/.claude/commands/docs-create.md
@@ -1,6 +1,6 @@
 ---
 description: 标准化文档创建
-argument-hint: [document-type] [document-title]
+argument-hint: "[document-type] [document-title]"
 ---
 
 <document-type>$1</document-type>

--- a/.claude/commands/docs-update.md
+++ b/.claude/commands/docs-update.md
@@ -1,6 +1,6 @@
 ---
 description: 文档批量更新和路径别名修复
-argument-hint: [scope] [target]
+argument-hint: "[scope] [target]"
 ---
 
 <scope>$1</scope>

--- a/.claude/commands/fix-github-comment.md
+++ b/.claude/commands/fix-github-comment.md
@@ -1,6 +1,6 @@
 ---
 description: 获取GitHub PR的Copilot评论并分析修复问题
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 ---
 
 # GitHub PR Copilot 评论分析和修复

--- a/.claude/commands/fix-test-case.md
+++ b/.claude/commands/fix-test-case.md
@@ -1,6 +1,6 @@
 ---
 description: 修复失败的测试用例
-argument-hint: [failed-test-file]
+argument-hint: "[failed-test-file]"
 ---
 
 <failed-test-file>$1</failed-test-file>

--- a/.claude/commands/fix-type-fail.md
+++ b/.claude/commands/fix-type-fail.md
@@ -1,6 +1,6 @@
 ---
 description: 修复类型检查失败
-argument-hint: [path, error-log]
+argument-hint: "[path, error-log]"
 ---
 
 我在目录 `<path>$1</path>` 执行命令 `nr type:check`

--- a/.claude/commands/gen-analyze.md
+++ b/.claude/commands/gen-analyze.md
@@ -1,6 +1,6 @@
 ---
 description: 问题分析
-argument-hint: [problem]
+argument-hint: "[problem]"
 ---
 
 # 问题分析

--- a/.claude/commands/test-create.md
+++ b/.claude/commands/test-create.md
@@ -1,6 +1,6 @@
 ---
 description: 测试用例生成流程
-argument-hint: [test-type] [target-file-or-module]
+argument-hint: "[test-type] [target-file-or-module]"
 ---
 
 <test-type>$1</test-type>

--- a/.claude/commands/tool-create.md
+++ b/.claude/commands/tool-create.md
@@ -1,6 +1,6 @@
 ---
 description: MCP工具开发流程
-argument-hint: [tool-name] [tool-description]
+argument-hint: "[tool-name] [tool-description]"
 ---
 
 <tool-name>$1</tool-name>


### PR DESCRIPTION
Closes #73.

## Summary

Purely mechanical single-character transform to 8 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (8)

- `.claude/commands/gen-analyze.md`
- `.claude/commands/fix-type-fail.md`
- `.claude/commands/docs-create.md`
- `.claude/commands/docs-update.md`
- `.claude/commands/tool-create.md`
- `.claude/commands/fix-github-comment.md`
- `.claude/commands/fix-test-case.md`
- `.claude/commands/test-create.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
